### PR TITLE
Update Devops Reading List

### DIFF
--- a/devops-reading-list.markdown
+++ b/devops-reading-list.markdown
@@ -12,6 +12,9 @@ permalink: /devops-reading-list/
 - [Building a DevOps Culture](http://www.amazon.com/Building-DevOps-Culture-Mandi-Walls-ebook/dp/B00CBM1WFC)
 - [Lean Enterprise](http://www.amazon.com/Lean-Enterprise-Performance-Organizations-Innovate-ebook/dp/B00QL5MSF8)
 - [Beyond Blame: Learning from Failure and Success](http://www.amazon.com/Beyond-Blame-Learning-Failure-Success-ebook/dp/B016CJ5HUA)
+- [The Field Guide to Understanding 'Human Error'](http://www.amazon.com/Field-Guide-Understanding-Human-Error-ebook/dp/B00Q8XCSFI)
+- [The Five Dysfunctions of a Team](http://www.amazon.com/Five-Dysfunctions-Team-Leadership-Fable/dp/0787960756)
+- [Turn the Ship Around](http://www.amazon.com/Turn-Ship-Around-Turning-Followers/dp/1591846404)
 
 ## Operations
 


### PR DESCRIPTION
This commit updates the DevOps reading list will three books I found very
helpful and insightful.

The Field Guide to understanding Human Error - Sidney Dekker
"It's in the world's best interest to read Dekkers book. The Field Guide is
nothing short of a paradigm shift in thinking about human error, and in my
domain of software and Internet engineering, it should be considered required
reading. This Third Edition is much better than the Second, and the layout of
the material is far more accessible.
John Allspaw, SVP, Infrastructure and Operations, Etsy"

The Five Dysfunctions of a Team - Patrick Lencioni
"... Lencioni weaves his lessons around the story of a troubled Silicon Valley
firm and its unexpected choice for a new CEO: an old-school manager who had
retired from a traditional manufacturing company two years earlier at age 55.
Showing exactly how existing personnel failed to function as a unit, and
precisely how the new boss worked to reestablish that essential conduct,
the book's first part colorfully illustrates the ways that teamwork can elude
even the most dedicated individuals--and be restored by an insightful leader."

Turn the Ship Around - David Marquet
"Turn the Ship Around! is the true story of how the Santa Fe skyrocketed from
worst to first in the fleet by challenging the U.S. Navy's traditional
leader-follower approach. Struggling against his own instincts to take control,
he instead achieved the vastly more powerful model of giving control."